### PR TITLE
Add security headers toggleable via config file ( bug 1018391 )

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -9,8 +9,19 @@ STORAGE=events.sqlite
 # Do you want dev routes and admin for all users?
 DEV=false
 
-# Force ssl?
+# Force ssl?  If set to false, be sure HSTS_DISABLED is set to 'true'
 FORCE_SSL=false
+
+# Disable HSTS? (set to 'true' to disable HSTS)
+HSTS_DISABLED='true'
+
+# Use Deny settings for X-Frame headers?
+# set to 'true' to disable X-frames-options denial
+DISABLE_XFO_HEADERS_DENY='false'
+
+# Use default XSS protection?
+# set to 'true' to disable IEXSS protection
+IEXSS_PROTECTION_DISABLED='false'
 
 # And a cookie secret
 SESSION_SECRET="dummy secret value"

--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 module.exports = function(env, db) {
   var express = require('express');
+  var helmet = require('helmet');
   var WebmakerAuth = require('webmaker-auth');
   var routes = require('./routes');
 
@@ -12,6 +13,18 @@ module.exports = function(env, db) {
   }
 
   var app = express();
+
+  // Check for helmet security options
+  if (process.env.HSTS_DISABLED != 'true') {
+    app.use(helmet.hsts());
+  }
+  if (process.env.DISABLE_XFO_HEADERS_DENY != 'true') {
+    app.use(helmet.xframe('deny'));
+  }
+  if (process.env.IEXSS_PROTECTION_DISABLED != 'true') {
+    app.use(helmet.iexss());
+  }
+
   var auth = new WebmakerAuth({
     loginURL: env.get('LOGIN_URL'),
     secretKey: env.get('SESSION_SECRET'),

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "express": "3.4.7",
     "habitat": "1.1.0",
     "hatchet": "0.1.0",
+    "helmet": "0.2.1",
     "sequelize": "1.7.3",
     "sqlite3": "2.2.0",
     "Faker": "0.5.11",


### PR DESCRIPTION
For bug : https://bugzilla.mozilla.org/show_bug.cgi?id=1018391

This adds three new config options:
# Disable HSTS? (set to 'true' to disable HSTS)

HSTS_DISABLED='true'
# Use Deny settings for X-Frame headers?
# set to 'true' to disable X-frames-options denial

DISABLE_XFO_HEADERS_DENY='false'
# Use default XSS protection?
# set to 'true' to disable IEXSS protection

IEXSS_PROTECTION_DISABLED='false'

This will allow us to turn these security headers on and off easily without deploying a new version.
